### PR TITLE
Remove common Micro.blog elements from head and use new partial instead

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -14,42 +14,11 @@
     {{ end }}
   </title>
 
-	<link rel="shortcut icon" href="https://micro.blog/{{ .Site.Author.username }}/favicon.png" type="image/x-icon" />
-
   <!-- CSS -->
   <link rel="stylesheet" href="{{ "css/poole.css" | relURL }}">
   <link rel="stylesheet" href="{{ "css/syntax.css" | relURL }}">
   <link rel="stylesheet" href="{{ "css/hyde.css" | relURL }}">
-  <link rel="stylesheet" href="{{ "custom.css" | relURL }}">
   <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=PT+Sans:400,400italic,700%7cAbril+Fatface">
 
-    {{ if .RSSLink -}}
-      <link href="{{ .RSSLink }}" rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" />
-      <link href="{{ "podcast.xml" | absURL }}" rel="alternate" type="application/rss+xml" title="Podcast" />
-      <link rel="alternate" type="application/json" title="{{ .Site.Title }}" href="{{ "feed.json" | absURL }}" />
-      <link rel="EditURI" type="application/rsd+xml" href="{{ "rsd.xml" | absURL }}" />
-    {{ end -}}
-
-	<link rel="me" href="https://micro.blog/{{ .Site.Author.username }}" />
-	{{ with .Site.Params.twitter_username }}
-		<link rel="me" href="https://twitter.com/{{ . }}" />
-	{{ end }}
-	{{ with .Site.Params.github_username }}
-		<link rel="me" href="https://github.com/{{ . }}" />
-	{{ end }}
-	{{ with .Site.Params.instagram_username }}
-		<link rel="me" href="https://instagram.com/{{ . }}" />
-	{{ end }}
-	<link rel="authorization_endpoint" href="https://micro.blog/indieauth/auth" />
-	<link rel="token_endpoint" href="https://micro.blog/indieauth/token" />
-	<link rel="micropub" href="https://micro.blog/micropub" />
-	<link rel="microsub" href="https://micro.blog/microsub" />
-	<link rel="webmention" href="https://micro.blog/webmention" />
-	<link rel="subscribe" href="https://micro.blog/users/follow" />
-	{{ range .Site.Params.plugins_css }}
-		<link rel="stylesheet" href="{{ . }}" />
-	{{ end }}
-	{{ range $filename := .Site.Params.plugins_html }}
-		{{ partial $filename $ }}
-	{{ end }}
+  {{ partial "microblog_head.html" . }}
 </head>


### PR DESCRIPTION
Here's Hyde making use of the new partial. Tests pass, and the build looks okay on Hugo 0.91 and 0.117.